### PR TITLE
Add W3C example harness

### DIFF
--- a/XPath/tests/test_w3c_public.py
+++ b/XPath/tests/test_w3c_public.py
@@ -1,0 +1,35 @@
+import json
+import os
+import unittest
+import xml.dom.minidom
+
+import xpath
+
+
+class TestW3CPublicCases(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        data_dir = os.path.join(os.path.dirname(__file__), 'w3c_data')
+        xml_path = os.path.join(data_dir, 'books.xml')
+        cls.doc = xml.dom.minidom.parse(xml_path)
+        with open(os.path.join(data_dir, 'testcases.json'), 'r', encoding='utf-8') as f:
+            cls.cases = json.load(f)
+
+    def eval_expr(self, expr, result_type, expected):
+        if result_type == 'number' or result_type == 'string':
+            value = xpath.findvalue(expr, self.doc)
+            self.assertEqual(value, expected)
+        elif result_type == 'nodeset':
+            values = xpath.findvalues(expr, self.doc)
+            self.assertEqual(values, expected)
+        else:
+            self.fail(f'Unknown result type: {result_type}')
+
+    def test_w3c_cases(self):
+        for case in self.cases:
+            with self.subTest(expr=case['expr']):
+                self.eval_expr(case['expr'], case['type'], case['expected'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/XPath/tests/w3c_data/books.xml
+++ b/XPath/tests/w3c_data/books.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<bookstore>
+  <book category="COOKING">
+    <title lang="en">Everyday Italian</title>
+    <author>Giada De Laurentiis</author>
+    <year>2005</year>
+    <price>30.00</price>
+  </book>
+  <book category="CHILDREN">
+    <title lang="en">Harry Potter</title>
+    <author>J K. Rowling</author>
+    <year>2005</year>
+    <price>29.99</price>
+  </book>
+  <book category="WEB">
+    <title lang="en">XQuery Kick Start</title>
+    <author>James McGovern</author>
+    <author>Per Bothner</author>
+    <author>Kurt Cagle</author>
+    <author>James Linn</author>
+    <author>Vaidyanathan Nagarajan</author>
+    <year>2003</year>
+    <price>49.99</price>
+  </book>
+  <book category="WEB" cover="paperback">
+    <title lang="en">Learning XML</title>
+    <author>Erik T. Ray</author>
+    <year>2003</year>
+    <price>39.95</price>
+  </book>
+</bookstore>

--- a/XPath/tests/w3c_data/testcases.json
+++ b/XPath/tests/w3c_data/testcases.json
@@ -1,0 +1,6 @@
+[
+  {"expr": "count(/bookstore/book)", "type": "number", "expected": 4},
+  {"expr": "string(/bookstore/book[1]/title)", "type": "string", "expected": "Everyday Italian"},
+  {"expr": "//book[@category='WEB']/title/text()", "type": "nodeset", "expected": ["XQuery Kick Start", "Learning XML"]},
+  {"expr": "(/bookstore/book/title)[last()]", "type": "string", "expected": "Learning XML"}
+]


### PR DESCRIPTION
## Summary
- add a small W3C-style sample XML document and test cases
- implement `test_w3c_public.py` to load the sample JSON and evaluate XPath expressions

## Testing
- `python -m unittest XPath.tests.test_w3c_public -v`
- `python -m unittest discover -s XPath/tests -p '*.py' -v`