### PR TITLE
Remove star imports and simplify rounding

### DIFF
--- a/XPath/xpath/__init__.py
+++ b/XPath/xpath/__init__.py
@@ -1,4 +1,12 @@
-from xpath.exceptions import *
+from xpath.exceptions import (
+    XPathError,
+    XPathNotImplementedError,
+    XPathParseError,
+    XPathTypeError,
+    XPathUnknownFunctionError,
+    XPathUnknownPrefixError,
+    XPathUnknownVariableError,
+)
 import xpath.exceptions
 import xpath.expr
 import xpath.parser

--- a/XPath/xpath/expr.py
+++ b/XPath/xpath/expr.py
@@ -1,4 +1,4 @@
-from itertools import *
+from itertools import chain, count
 import math
 import operator
 import re
@@ -6,12 +6,18 @@ import xml.dom
 import weakref
 import sys
 
-from xpath.exceptions import *
+from xpath.exceptions import (
+    XPathNotImplementedError,
+    XPathTypeError,
+    XPathUnknownFunctionError,
+    XPathUnknownPrefixError,
+    XPathUnknownVariableError,
+)
 import xpath
 
-# Workaround for Python 2 and 3 differences
+# Helper for XPath round() that preserves NaN and infinities
 def _round(n):
-    if hasattr(math, "isfinite") and not math.isfinite(n):
+    if not math.isfinite(n):
         return n
     return round(n)
 

--- a/XPath/xpath/parser.g
+++ b/XPath/xpath/parser.g
@@ -1,5 +1,5 @@
 import xpath.expr as X
-from xpath.yappsrt import *
+from xpath.yappsrt import Parser, Scanner, wrap_error_reporter
 
 %%
 

--- a/XPath/xpath/parser.py
+++ b/XPath/xpath/parser.py
@@ -1,5 +1,5 @@
 import xpath.expr as X
-from xpath.yappsrt import *
+from xpath.yappsrt import Parser, Scanner, wrap_error_reporter
 
 
 import re

--- a/XPath/yapps2/parsedesc.py
+++ b/XPath/yapps2/parsedesc.py
@@ -35,9 +35,8 @@ def resolve_name(tokens, id, args):
         return NonTerminal(id, args)
 
 
-from string import *
 import re
-from yappsrt import *
+from yappsrt import Parser, Scanner, SyntaxError, wrap_error_reporter
 
 class ParserDescriptionScanner(Scanner):
     patterns = [

--- a/XPath/yapps2/yapps2.patch
+++ b/XPath/yapps2/yapps2.patch
@@ -1,13 +1,11 @@
 diff -u yapps2.orig/yapps2.py yapps2/yapps2.py
 --- yapps2.orig/yapps2.py	2003-08-03 10:11:45.000000000 -0700
 +++ yapps2/yapps2.py	2009-02-05 15:36:54.000000000 -0800
-@@ -166,7 +166,8 @@
-         # TODO: remove "import *" construct
+@@ -166,6 +166,7 @@
          self.write("from string import *\n")
          self.write("import re\n")
--        self.write("from yappsrt import *\n")
-+        if not self['no-support-module']:
-+            self.write("from yappsrt import *\n")
+         if not self['no-support-module']:
+             self.write("from yappsrt import *\n")
  	self.write("\n")
  	self.write("class ", self.name, "Scanner(Scanner):\n")
          self.write("    patterns = [\n")

--- a/XPath/yapps2/yapps2.py
+++ b/XPath/yapps2/yapps2.py
@@ -26,7 +26,7 @@
 # * Style change: replaced raise "string exception" with raise
 #   ClassException(...) (thanks Alex Verstak)
 
-from yappsrt import *
+from yappsrt import Parser, Scanner, SyntaxError, wrap_error_reporter
 import sys
 import re
 
@@ -163,10 +163,11 @@ class Generator(object):
     def generate_output(self):
         self.calculate()
         self.write(self.preparser)
-        # TODO: remove "import *" construct
         self.write("import re\n")
         if not self['no-support-module']:
-            self.write("from yappsrt import *\n")
+            self.write(
+                "from yappsrt import Parser, Scanner, SyntaxError, wrap_error_reporter\n"
+            )
         self.write("\n")
         self.write("class ", self.name, "Scanner(Scanner):\n")
         self.write("    patterns = [\n")
@@ -561,9 +562,8 @@ def resolve_name(tokens, id, args):
         return NonTerminal(id, args)
 
 
-from string import *
 import re
-from yappsrt import *
+from yappsrt import Parser, Scanner, SyntaxError, wrap_error_reporter
 
 class ParserDescriptionScanner(Scanner):
     def __init__(self, str):


### PR DESCRIPTION
## Summary
- switch to explicit imports in parser and expression modules
- rely on math.isfinite in `_round`
- clean up comments in `yapps2`
- update Yapps grammar and parser

## Testing
- `python setup.py test`