### PR TITLE
Enable pytest discovery

### DIFF
--- a/XPath/README
+++ b/XPath/README
@@ -35,3 +35,15 @@ permitted the author to release it under the MIT license.
 For further details, visit the project home page at:
 
     http://code.google.com/p/py-dom-xpath/
+
+Running the test suite
+----------------------
+
+The preferred way to run the tests is with `pytest`::
+
+    pytest -q
+
+If `pytest` is not available, you can still run the tests with the
+standard library `unittest` module::
+
+    python -m unittest discover -s XPath/tests -p 'test_*.py' -v

--- a/XPath/tests/test_abbreviations.py
+++ b/XPath/tests/test_abbreviations.py
@@ -284,5 +284,3 @@ class TestAbbreviations(unittest.TestCase):
         self.assertEqual([x.getAttribute("name") for x in result],
                              ["Dianne"])
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_api.py
+++ b/XPath/tests/test_api.py
@@ -149,5 +149,3 @@ class TestNamespacesAPI(unittest.TestCase):
         result = context.findvalues('//pork:item', self.doc)
         self.assertEqual(result, ['porcupine'])
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_axes.py
+++ b/XPath/tests/test_axes.py
@@ -112,6 +112,4 @@ class TestAxes(unittest.TestCase):
 
         self.assertEqual(a, b)
 
-if __name__ == '__main__':
-    unittest.main()
 

--- a/XPath/tests/test_data.py
+++ b/XPath/tests/test_data.py
@@ -123,5 +123,3 @@ class TestDataModel(unittest.TestCase):
         result = self.context.find('local-name(//element/text())', self.doc)
         self.assertEqual(result, "")
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_expressions.py
+++ b/XPath/tests/test_expressions.py
@@ -441,5 +441,3 @@ class TestPrecedence(unittest.TestCase):
         result = xpath.find('3 + 4 div 2 - 4 * 1 div 2', self.doc)
         self.assertEqual(result, 3)
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_functions.py
+++ b/XPath/tests/test_functions.py
@@ -428,5 +428,3 @@ class TestNumberFunctions(unittest.TestCase):
         result = xpath.find('round(-1 div 0)', self.doc)
         self.assertEqual(result, float('-inf'))
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_nodetests.py
+++ b/XPath/tests/test_nodetests.py
@@ -146,6 +146,4 @@ class TestKindTests(unittest.TestCase):
         self.assertEqual([x.target for x in result],
                              ['two'])
 
-if __name__ == '__main__':
-    unittest.main()
 

--- a/XPath/tests/test_paths.py
+++ b/XPath/tests/test_paths.py
@@ -442,5 +442,3 @@ class PathsTestCase(unittest.TestCase):
         result = xpath.find("//processing-instruction", doc)
         self.assertEqual([x.getAttribute("id") for x in result], ["1"])
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_predicates.py
+++ b/XPath/tests/test_predicates.py
@@ -87,5 +87,3 @@ class TestPredicates(unittest.TestCase):
         self.assertEqual([x.getAttribute("id") for x in result],
                              ["2"])
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_repr.py
+++ b/XPath/tests/test_repr.py
@@ -51,5 +51,3 @@ class TestRepr(unittest.TestCase):
             self.assertEqual(str(expr1), str(expr2))
             self.assertEqual(str(expr1), str(expr3))
 
-if __name__ == '__main__':
-    unittest.main()

--- a/XPath/tests/test_w3c_public.py
+++ b/XPath/tests/test_w3c_public.py
@@ -31,5 +31,3 @@ class TestW3CPublicCases(unittest.TestCase):
                 self.eval_expr(case['expr'], case['type'], case['expected'])
 
 
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
## Summary
- rename test files with `test_` prefix so pytest can find them
- remove standalone `unittest.main` blocks
- document running the tests with `pytest`

## Testing
- `pytest -q`
