### PR TITLE
Add tests comparing with external libraries

### DIFF
--- a/XPath/tests/test_elementpath_compare.py
+++ b/XPath/tests/test_elementpath_compare.py
@@ -1,0 +1,49 @@
+import json
+import os
+import unittest
+import xml.dom.minidom
+from xml.etree import ElementTree as ET
+
+import xpath
+
+try:
+    import elementpath
+except ImportError:  # pragma: no cover - library optional
+    elementpath = None
+
+
+class TestComparisonWithElementPath(unittest.TestCase):
+    """Check selected expressions against elementpath's XPath 1.0 engine."""
+
+    @classmethod
+    def setUpClass(cls):
+        data_dir = os.path.join(os.path.dirname(__file__), 'w3c_data')
+        xml_path = os.path.join(data_dir, 'books.xml')
+        cls.et_root = ET.parse(xml_path).getroot()
+        cls.doc = xml.dom.minidom.parse(xml_path)
+        with open(os.path.join(data_dir, 'testcases_more.json'), 'r', encoding='utf-8') as f:
+            cls.cases = json.load(f)
+
+    @unittest.skipUnless(elementpath, 'elementpath library not available')
+    def test_results_match_elementpath(self):
+        for case in self.cases:
+            with self.subTest(expr=case['expr']):
+                ep_result = elementpath.select(
+                    self.et_root, case['expr'], parser=elementpath.XPath1Parser
+                )
+                if case['type'] == 'nodeset':
+                    ep_values = [
+                        e.text if hasattr(e, 'text') else str(e)
+                        for e in ep_result
+                    ]
+                    xp_values = xpath.findvalues(case['expr'], self.doc)
+                    self.assertEqual(xp_values, ep_values)
+                elif case['type'] in ('number', 'string'):
+                    xp_value = xpath.findvalue(case['expr'], self.doc)
+                    if case['type'] == 'number':
+                        ep_value = float(ep_result)
+                    else:
+                        ep_value = str(ep_result)
+                    self.assertEqual(xp_value, ep_value)
+                else:
+                    self.fail('Unknown result type: %s' % case['type'])

--- a/XPath/tests/test_namespaces_examples.py
+++ b/XPath/tests/test_namespaces_examples.py
@@ -1,0 +1,32 @@
+import os
+import unittest
+import xml.dom.minidom
+
+import xpath
+
+
+class TestNamespaceExamples(unittest.TestCase):
+    """Namespace related examples including unsupported features."""
+
+    @classmethod
+    def setUpClass(cls):
+        data_dir = os.path.join(os.path.dirname(__file__), 'w3c_data')
+        xml_path = os.path.join(data_dir, 'ns_books.xml')
+        cls.doc = xml.dom.minidom.parse(xml_path)
+
+    def test_default_namespace_selection(self):
+        ctx = xpath.XPathContext(default_namespace='http://example.com/book')
+        result = ctx.find('count(//book)', self.doc)
+        self.assertEqual(result, 2)
+
+    def test_wildcard_prefix(self):
+        values = xpath.findvalues('//*:title', self.doc)
+        self.assertEqual(values, ['Book One', 'Book Two'])
+
+    def test_unknown_prefix_error(self):
+        with self.assertRaises(xpath.XPathUnknownPrefixError):
+            xpath.find('//un:book', self.doc)
+
+    def test_namespace_axis_not_implemented(self):
+        with self.assertRaises(xpath.XPathNotImplementedError):
+            xpath.find('//book/namespace::*', self.doc)

--- a/XPath/tests/test_unsupported_xpath2.py
+++ b/XPath/tests/test_unsupported_xpath2.py
@@ -1,0 +1,29 @@
+import unittest
+import xml.dom.minidom
+
+import xpath
+
+try:
+    import elementpath
+except ImportError:  # pragma: no cover - library optional
+    elementpath = None
+
+
+class TestUnsupportedXPath2Functions(unittest.TestCase):
+    """Verify XPath 2.0 functions are rejected."""
+
+    xml = '<root><a>text</a></root>'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = xml.dom.minidom.parseString(cls.xml)
+        if elementpath:
+            from xml.etree import ElementTree as ET
+            cls.et_root = ET.fromstring(cls.xml)
+
+    def test_upper_case_not_supported(self):
+        with self.assertRaises(xpath.XPathUnknownFunctionError):
+            xpath.find('upper-case("abc")', self.doc)
+        if elementpath:
+            result = elementpath.select(self.et_root, 'upper-case("abc")', parser=elementpath.XPath2Parser)
+            self.assertEqual(result, 'ABC')

--- a/XPath/tests/test_w3c_more.py
+++ b/XPath/tests/test_w3c_more.py
@@ -1,0 +1,33 @@
+import json
+import os
+import unittest
+import xml.dom.minidom
+
+import xpath
+
+
+class TestW3CAdditionalCases(unittest.TestCase):
+    """Extra XPath 1.0 examples from the W3C documentation."""
+
+    @classmethod
+    def setUpClass(cls):
+        data_dir = os.path.join(os.path.dirname(__file__), 'w3c_data')
+        xml_path = os.path.join(data_dir, 'books.xml')
+        cls.doc = xml.dom.minidom.parse(xml_path)
+        with open(os.path.join(data_dir, 'testcases_more.json'), 'r', encoding='utf-8') as f:
+            cls.cases = json.load(f)
+
+    def eval_expr(self, expr, result_type, expected):
+        if result_type in ('number', 'string'):
+            value = xpath.findvalue(expr, self.doc)
+            self.assertEqual(value, expected)
+        elif result_type == 'nodeset':
+            values = xpath.findvalues(expr, self.doc)
+            self.assertEqual(values, expected)
+        else:
+            self.fail(f'Unknown result type: {result_type}')
+
+    def test_w3c_additional_cases(self):
+        for case in self.cases:
+            with self.subTest(expr=case['expr']):
+                self.eval_expr(case['expr'], case['type'], case['expected'])

--- a/XPath/tests/test_xmlunittest_examples.py
+++ b/XPath/tests/test_xmlunittest_examples.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+import xml.dom.minidom
+
+import xpath
+import xmlunittest
+from lxml import etree
+
+
+class TestXmlUnittest(xmlunittest.XmlTestCase):
+    """Demonstrate xmlunittest assertions alongside xpath results."""
+
+    @classmethod
+    def setUpClass(cls):
+        data_dir = os.path.join(os.path.dirname(__file__), 'w3c_data')
+        xml_path = os.path.join(data_dir, 'books.xml')
+        cls.lxml_doc = etree.parse(xml_path).getroot()
+        cls.dom_doc = xml.dom.minidom.parse(xml_path)
+
+    def test_assert_xpath_values(self):
+        expected = [
+            'Everyday Italian',
+            'Harry Potter',
+            'XQuery Kick Start',
+            'Learning XML',
+        ]
+        self.assertXpathValues(self.lxml_doc, '/bookstore/book/title/text()', expected)
+        values = xpath.findvalues('/bookstore/book/title/text()', self.dom_doc)
+        self.assertEqual(values, expected)
+
+    def test_assert_xpath_exists(self):
+        self.assertXpathsExist(self.lxml_doc, ['/bookstore/book[@category="WEB"]'])
+        count_web = xpath.find('count(/bookstore/book[@category="WEB"])', self.dom_doc)
+        self.assertEqual(count_web, 2)

--- a/XPath/tests/w3c_data/ns_books.xml
+++ b/XPath/tests/w3c_data/ns_books.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<bookstore xmlns="http://example.com/book" xmlns:bk="http://example.com/book">
+  <book category="WEB">
+    <title lang="en">Book One</title>
+    <price>10</price>
+  </book>
+  <bk:book category="WEB">
+    <bk:title lang="en">Book Two</bk:title>
+    <bk:price>20</bk:price>
+  </bk:book>
+</bookstore>

--- a/XPath/tests/w3c_data/testcases_more.json
+++ b/XPath/tests/w3c_data/testcases_more.json
@@ -1,0 +1,8 @@
+[
+  {"expr": "//book[price>35]/title/text()", "type": "nodeset", "expected": ["XQuery Kick Start", "Learning XML"]},
+  {"expr": "sum(/bookstore/book/price)", "type": "number", "expected": 149.93},
+  {"expr": "name(/bookstore/book[1])", "type": "string", "expected": "book"},
+  {"expr": "count(/bookstore/book/author)", "type": "number", "expected": 8},
+  {"expr": "//book[price<40]/title/text()", "type": "nodeset", "expected": ["Everyday Italian", "Harry Potter", "Learning XML"]},
+  {"expr": "count(/bookstore/book[@category='WEB'])", "type": "number", "expected": 2}
+]


### PR DESCRIPTION
## Summary
- add comparison tests against `elementpath`
- demonstrate xmlunittest helpers with existing XML data
- verify XPath 2.0 functions raise the expected error

## Testing
- `pytest -q`