### PR TITLE
Update ignore patterns for docs and caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
 build
 .tox
+
+# Generated documentation
+doc/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+dist/
+*.egg-info/
+
+# Testing artifacts
+.pytest_cache/


### PR DESCRIPTION
## Summary
- extend `.gitignore` for generated documentation and caches

## Testing
- `pytest -q`