### PR TITLE
Add lxml/elementpath test extras

### DIFF
--- a/XPath/pyproject.toml
+++ b/XPath/pyproject.toml
@@ -25,4 +25,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = [
+    "pytest",
+    "lxml",
+    "elementpath",
+]

--- a/XPath/setup.cfg
+++ b/XPath/setup.cfg
@@ -20,3 +20,5 @@ classifiers =
 [options.extras_require]
 test =
     pytest
+    lxml
+    elementpath


### PR DESCRIPTION
## Summary
- include `lxml` and `elementpath` in `test` extras
- keep test install configuration in both `setup.cfg` and `pyproject.toml`

## Testing
- `pytest -q`