### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v1

--- a/XPath/README
+++ b/XPath/README
@@ -4,8 +4,8 @@ namespace axis. It operates on DOM 2.0 nodes, and works well with
 xml.dom.minidom, but also with other xml.dom implementations.
 
 py-dom-xpath-six is a version of py-dom-xpath that is compatible with Python
-3.6 and later. It is a fork of py-dom-xpath-redux, which in turn is a fork of
-the original py-dom-xpath.  This package therefore requires Python 3.6 or
+3.8 and later. It is a fork of py-dom-xpath-redux, which in turn is a fork of
+the original py-dom-xpath.  This package therefore requires Python 3.8 or
 newer.
 
 Changes in 0.2.4:
@@ -23,7 +23,7 @@ supports almost all XPath 1.0, with the main exception being the
 namespace axis. It operates on DOM 2.0 nodes, and works well with
 xml.dom.minidom.
 
-py-dom-xpath-six requires Python 3.6 or greater.
+py-dom-xpath-six requires Python 3.8 or greater.
 
 py-dom-xpath uses the Yapps 2 parser generator by Amit J. Patel.
 The package now relies on the standard `yapps2` distribution available

--- a/XPath/pyproject.toml
+++ b/XPath/pyproject.toml
@@ -10,7 +10,7 @@ name = "py-dom-xpath-six"
 version = "0.2.4"
 description = "XPath for DOM trees"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 authors = [
   { name = "Damien Neil" }
 ]

--- a/XPath/tox.ini
+++ b/XPath/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py38, py39, py310, py311, py312
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
## Summary
- drop EOL Python versions from tox and CI
- add Python 3.11 and 3.12 to CI matrix
- update minimum required version in documentation and metadata

## Testing
- `pytest -q`